### PR TITLE
fix: Remove panic statement for missing .env-file

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -18,8 +18,7 @@ func main() {
 	router := createRouter()
 
 	if err := godotenv.Load(); err != nil {
-		log.Fatalf("Error loading .env file: %v", err)
-		panic(err)
+		log.Printf("Error loading .env file: %v", err)
 	}
 
 	// GET ENVIRONMENT VARIABLES


### PR DESCRIPTION
The .env file is not part of the docker image and will throw an error. Log.Fatal is replaces by a print statement.

## Description

The .env file is not part of the docker image and will throw an error. Log.Fatal is replaces by a print statement.

Fixes # (issue reference, if applicable)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Locally tested the according endpoints
- [ ] Ran E2E-Tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
